### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "szepeviktor/wp-cli-database-prefix-command",
-	"type": "command",
+	"type": "wp-cli-package",
 	"description": "Perform operations on prefixed database tables.",
 	"keywords": ["wp-cli","database","prefix"],
 	"homepage": "https://github.com/szepeviktor/wp-cli-database-prefix-command",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
